### PR TITLE
fix: strip <em> tags before rendering math blocks

### DIFF
--- a/markdown/test.md
+++ b/markdown/test.md
@@ -3,3 +3,13 @@
 Following *should not* render properly:
 
 Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.
+
+An `inline block` and $\text{H}_h + X_\text{x}$.
+
+```js
+// test code block
+test();
+```
+
+- A list
+- Another problematic $\text{H}_h + X_\text{x}$

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -1,5 +1,5 @@
 # For testing purposes
 
-Following should not render properly:
+Following *should not* render properly:
 
-$\text{H}_h + X_\text{x}$
+Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -6,6 +6,13 @@ Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.
 
 An `inline block` and $\text{H}_h + X_\text{x}$.
 
+$$
+\begin{aligned}
+&\frac{C}{C^*} \leq \rho(n) \rightarrow \text{ for minimisation, } \rho(n) \geq 1 \\
+&\frac{C}{C^*} \geq \rho(n) \rightarrow \text{ for maximisation, } \rho(n) \leq 1
+\end{aligned}
+$$
+
 ```js
 // test code block
 test();

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,41 @@
 import renderMathInElement from "katex/dist/contrib/auto-render";
 import { Messages } from "./utils/constants";
 
+function stripEmTags() {
+  const readme = document.getElementById("readme");
+
+  if (!readme) {
+    return;
+  }
+
+  let pos = 0;
+  while (pos >= 0) {
+    console.log(pos);
+    // find first pos of "}<em>"
+    pos = readme.innerHTML.indexOf("}<em>", pos);
+    // replace "}<em>" and "</em>" after pos
+    readme.innerHTML =
+      readme.innerHTML.slice(0, pos) +
+      readme.innerHTML
+        .slice(pos)
+        .replace("}<em>", "}_")
+        .replace("</em>", "_");
+  }
+
+  pos = 0;
+  while (pos >= 0) {
+    // find first pos of "^<em>"
+    pos = readme.innerHTML.indexOf("^<em>", pos);
+    // replace "^<em>" and "</em>" after pos
+    readme.innerHTML =
+      readme.innerHTML.slice(0, pos) +
+      readme.innerHTML
+        .slice(pos)
+        .replace("^<em>", "^*")
+        .replace("</em>", "*");
+  }
+}
+
 function renderMath() {
   const readme = document.getElementById("readme");
 
@@ -47,7 +82,9 @@ const readmeObserver = new MutationObserver((mutations) => {
     for (const addedNode of mutation.addedNodes) {
       if (addedNode.id === "readme") {
         console.log("readme dom change detected");
-        return renderMath();
+        stripEmTags();
+        renderMath();
+        return; // break from all loops
       }
     }
   }
@@ -58,10 +95,12 @@ readmeObserver.observe(document.body, { childList: true, subtree: true });
 chrome.runtime.onMessage.addListener((request) => {
   if (request.type === Messages.ROUTE_CHANGED) {
     console.log("route change detected");
+    stripEmTags();
     renderMath();
   }
 });
 
 // on initial page load
 console.log("initial page load detected");
+stripEmTags();
 renderMath();

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ function stripEmTags() {
 
   let pos = 0;
   while (pos >= 0) {
-    console.log(pos);
     // find first pos of "}<em>"
     pos = readme.innerHTML.indexOf("}<em>", pos);
     // replace "}<em>" and "</em>" after pos


### PR DESCRIPTION
- Common problematic latex syntax include `}_` and `^*`, which GitHub will parse as `}<em>` and `^<em>` respectively
- This fix finds in the DOM all instances of `}<em>` and `^<em>`, and the corresponding closing `</em>` and replaces them appropriately
- Has potential to cause problems since *all instances*, instead of only those in math blocks are replaced

Fixes #1.