### PR TITLE
fix: transform problematic HTML tags before rendering math blocks

### DIFF
--- a/markdown/test.md
+++ b/markdown/test.md
@@ -22,6 +22,16 @@ Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.
 
 An `inline block` and $\text{H}_h + X_\text{x}$.
 
+Normal break  
+Next line
+
+$$
+\begin{aligned}
+x &= 2\\  
+y &= 3
+\end{aligned}
+$$
+
 $$
 \begin{aligned}
 &\frac{C}{C^*} \leq \rho(n) \rightarrow \text{ for minimisation, } \rho(n) \geq 1 \\

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -8,6 +8,14 @@
 
 {hello}\_hello\_
 
+(hello)*hello*
+
+{hello}*hello*
+
+(hello)\*hello\*
+
+{hello}\*hello\*
+
 $(f_{i})_{\ast}\mathscr{H}\rightarrow f_{i}(z)$
 
 Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -4,6 +4,10 @@
 
 {hello}_hello_
 
+(hello)\_hello\_
+
+{hello}\_hello\_
+
 $(f_{i})_{\ast}\mathscr{H}\rightarrow f_{i}(z)$
 
 Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -1,6 +1,8 @@
 # For testing purposes
 
-Following *should not* render properly:
+(hello)_hello_
+
+{hello}_hello_
 
 $(f_{i})_{\ast}\mathscr{H}\rightarrow f_{i}(z)$
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,60 +1,26 @@
 import renderMathInElement from "katex/dist/contrib/auto-render";
 import { Messages } from "./utils/constants";
 
-function transformProblematicEmTags() {
-  const readme = document.getElementById("readme");
-
-  if (!readme) {
-    return;
-  }
-
-  let pos = 0;
-  while (pos >= 0) {
-    // find first pos of "}<em>"
-    pos = readme.innerHTML.indexOf("}<em>", pos);
-    // replace "}<em>" and "</em>" after pos
-    readme.innerHTML =
-      readme.innerHTML.slice(0, pos) +
-      readme.innerHTML
-        .slice(pos)
-        .replace("}<em>", "}_")
-        .replace("</em>", "_");
-  }
-
-  pos = 0;
-  while (pos >= 0) {
-    // find first pos of ")<em>"
-    pos = readme.innerHTML.indexOf(")<em>", pos);
-    // replace ")<em>" and "</em>" after pos
-    readme.innerHTML =
-      readme.innerHTML.slice(0, pos) +
-      readme.innerHTML
-        .slice(pos)
-        .replace(")<em>", ")_")
-        .replace("</em>", "_");
-  }
-
-  pos = 0;
-  while (pos >= 0) {
-    // find first pos of "^<em>"
-    pos = readme.innerHTML.indexOf("^<em>", pos);
-    // replace "^<em>" and "</em>" after pos
-    readme.innerHTML =
-      readme.innerHTML.slice(0, pos) +
-      readme.innerHTML
-        .slice(pos)
-        .replace("^<em>", "^*")
-        .replace("</em>", "*");
-  }
+function transformProblematicTags(readme) {
+  readme.innerHTML = readme.innerHTML
+    // replace "}<em> ... </em>" with "}\@@em@start@@_ ... \@@em@end@@_"
+    .replace(/}<em.*?>([\s\S]*?)<\/em>/g, "}\\@@em@start@@_$1\\@@em@end@@_")
+    // replace ")<em> ... </em>" with ")\@@em@start@@_ ... \@@em@end@@_"
+    .replace(/\)<em.*?>([\s\S]*?)<\/em>/g, ")\\@@em@start@@_$1\\@@em@end@@_")
+    // replace "^<em> ... </em>" with "^\@@em@start@@* ... \@@em@end@@*"
+    .replace(/\^<em.*?>([\s\S]*?)<\/em>/g, "^\\@@em@start@@*$1\\@@em@end@@*")
+    // replace "<br>" with "\@@br@@"
+    .replace(/\\*<br.*?>/g, "\\@@br@@");
 }
 
-function renderMath() {
-  const readme = document.getElementById("readme");
+function revertNonProblematicTags(readme) {
+  readme.innerHTML = readme.innerHTML
+    .replace(/\\@@em@start@@_([\s\S]*?)\\@@em@end@@_/g, "<em>$1</em>")
+    .replace(/\\@@em@start@@\*([\s\S]*?)\\@@em@end@@\*/g, "<em>$1</em>")
+    .replace(/\\@@br@@/g, "<br>");
+}
 
-  if (!readme) {
-    return;
-  }
-
+function renderMathViaKatex(readme) {
   renderMathInElement(readme, {
     delimiters: [
       { left: "$$", right: "$$", display: true },
@@ -82,10 +48,27 @@ function renderMath() {
 
       // for \; spacing
       ";": "\\;",
+
+      // replace custom tags
+      "\\@@em@start@@": "",
+      "\\@@em@end@@": "",
+      "\\@@br@@": "\\\\",
     },
   });
 
   console.log("math rendered");
+}
+
+function renderMath() {
+  const readme = document.getElementById("readme");
+
+  if (!readme) {
+    return;
+  }
+
+  transformProblematicTags(readme);
+  renderMathViaKatex(readme);
+  revertNonProblematicTags(readme);
 }
 
 // on detected dom changes (when previewing markdown)
@@ -94,7 +77,6 @@ const readmeObserver = new MutationObserver((mutations) => {
     for (const addedNode of mutation.addedNodes) {
       if (addedNode.id === "readme") {
         console.log("readme dom change detected");
-        transformProblematicEmTags();
         renderMath();
         return; // break from all loops
       }
@@ -107,12 +89,10 @@ readmeObserver.observe(document.body, { childList: true, subtree: true });
 chrome.runtime.onMessage.addListener((request) => {
   if (request.type === Messages.ROUTE_CHANGED) {
     console.log("route change detected");
-    transformProblematicEmTags();
     renderMath();
   }
 });
 
 // on initial page load
 console.log("initial page load detected");
-transformProblematicEmTags();
 renderMath();

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import renderMathInElement from "katex/dist/contrib/auto-render";
 import { Messages } from "./utils/constants";
 
-function stripEmTags() {
+function transformProblematicEmTags() {
   const readme = document.getElementById("readme");
 
   if (!readme) {
@@ -18,6 +18,19 @@ function stripEmTags() {
       readme.innerHTML
         .slice(pos)
         .replace("}<em>", "}_")
+        .replace("</em>", "_");
+  }
+
+  pos = 0;
+  while (pos >= 0) {
+    // find first pos of ")<em>"
+    pos = readme.innerHTML.indexOf(")<em>", pos);
+    // replace ")<em>" and "</em>" after pos
+    readme.innerHTML =
+      readme.innerHTML.slice(0, pos) +
+      readme.innerHTML
+        .slice(pos)
+        .replace(")<em>", ")_")
         .replace("</em>", "_");
   }
 
@@ -81,7 +94,7 @@ const readmeObserver = new MutationObserver((mutations) => {
     for (const addedNode of mutation.addedNodes) {
       if (addedNode.id === "readme") {
         console.log("readme dom change detected");
-        stripEmTags();
+        transformProblematicEmTags();
         renderMath();
         return; // break from all loops
       }
@@ -94,12 +107,12 @@ readmeObserver.observe(document.body, { childList: true, subtree: true });
 chrome.runtime.onMessage.addListener((request) => {
   if (request.type === Messages.ROUTE_CHANGED) {
     console.log("route change detected");
-    stripEmTags();
+    transformProblematicEmTags();
     renderMath();
   }
 });
 
 // on initial page load
 console.log("initial page load detected");
-stripEmTags();
+transformProblematicEmTags();
 renderMath();


### PR DESCRIPTION
Related to #2. Fixes #3.

Current implementation:

1. Problematic HTML tags (even if not within math blocks) will be transformed to its corresponding custom macro (eg. `\@@em@start@@`)
2. KaTeX will then render the math with the custom macros
3. Any macros still found will then be transformed back to its corresponding HTML tags (since they are false positive)