### PR TITLE
fix: remove custom tags from rendered katex blocks before reverting

### DIFF
--- a/markdown/test.md
+++ b/markdown/test.md
@@ -24,6 +24,8 @@ $U_{j}\in\mathscr{U}_{j}$
 
 $U\in\mathscr{U}_{1}\cap\dotsb\cap\mathscr{U}_{n}\subset\mathscr{V}$
 
+ところが$U_{j}\subset U$より$U\in\mathscr{U}_{j}$を得る。つまり$U\in\mathscr{U}_{1}\cap\dotsb\cap\mathscr{U}_{n}\subset\mathscr{V}$となり矛盾する。
+
 (hello)_hello_
 
 {hello}_hello_

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -1,30 +1,6 @@
 # For testing purposes
 
-$\bigcap_{\lambda\in\Lambda}\mathscr{F}_{\lambda}$
-
-$(Y_{i}, \mathscr{G}_{i})$
-
-$f_{i}\colon X\rightarrow Y_{i}$
-
-$h^{-1}(f_{i}^{-1}(G_{i}))\in\mathscr{H}$
-
-$(f_{i}\circ h)^{-1}(G_{i})\in\mathscr{H}$
-
-$(\prod Y_{i}, \prod\mathscr{G}_{i})$
-
-$\lbrace g_{ij}\circ f_{i} : i\in I, j\in J_{i} \rbrace$
-
-$V\cap W\in\mathscr{A}_{\neg S}$
-
-$\mathscr{V}\neq\mathscr{U}_{j}$
-
-$\mathscr{U}_{j}$
-
-$U_{j}\in\mathscr{U}_{j}$
-
-$U\in\mathscr{U}_{1}\cap\dotsb\cap\mathscr{U}_{n}\subset\mathscr{V}$
-
-ところが$U_{j}\subset U$より$U\in\mathscr{U}_{j}$を得る。つまり$U\in\mathscr{U}_{1}\cap\dotsb\cap\mathscr{U}_{n}\subset\mathscr{V}$となり矛盾する。
+$U\in\mathscr{U}_{j}$ NORMAL TEXT $U\in\mathscr{U}_{1}\cap\dotsb\cap\mathscr{U}_{n}\subset\mathscr{V}$
 
 (hello)_hello_
 

--- a/markdown/test.md
+++ b/markdown/test.md
@@ -1,5 +1,29 @@
 # For testing purposes
 
+$\bigcap_{\lambda\in\Lambda}\mathscr{F}_{\lambda}$
+
+$(Y_{i}, \mathscr{G}_{i})$
+
+$f_{i}\colon X\rightarrow Y_{i}$
+
+$h^{-1}(f_{i}^{-1}(G_{i}))\in\mathscr{H}$
+
+$(f_{i}\circ h)^{-1}(G_{i})\in\mathscr{H}$
+
+$(\prod Y_{i}, \prod\mathscr{G}_{i})$
+
+$\lbrace g_{ij}\circ f_{i} : i\in I, j\in J_{i} \rbrace$
+
+$V\cap W\in\mathscr{A}_{\neg S}$
+
+$\mathscr{V}\neq\mathscr{U}_{j}$
+
+$\mathscr{U}_{j}$
+
+$U_{j}\in\mathscr{U}_{j}$
+
+$U\in\mathscr{U}_{1}\cap\dotsb\cap\mathscr{U}_{n}\subset\mathscr{V}$
+
 (hello)_hello_
 
 {hello}_hello_
@@ -17,8 +41,6 @@
 {hello}\*hello\*
 
 $(f_{i})_{\ast}\mathscr{H}\rightarrow f_{i}(z)$
-
-Some text before, the math: $\text{H}_h + X_\text{x}$, and some *italics after*.
 
 An `inline block` and $\text{H}_h + X_\text{x}$.
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,22 @@ function transformProblematicTags(readme) {
     .replace(/\\*<br.*?>/g, "\\@@br@@");
 }
 
+/**
+ * Cleans and removes the custom tags introduced in {@function transformProblematicTags}
+ * for all KaTeX nodes.
+ *
+ * @param {HTMLElement} readme
+ */
+function cleanTagsFromKatexElements(readme) {
+  const katexElements = readme.getElementsByClassName("katex");
+  for (const el of katexElements) {
+    el.innerHTML = el.innerHTML
+      .replace(/\\@@em@start@@/g, "")
+      .replace(/\\@@em@end@@/g, "")
+      .replace(/\\@@br@@/g, "\\\\");
+  }
+}
+
 function revertNonProblematicTags(readme) {
   readme.innerHTML = readme.innerHTML
     .replace(/\\@@em@start@@_([\s\S]*?)\\@@em@end@@_/g, "<em>$1</em>")
@@ -68,6 +84,7 @@ function renderMath() {
 
   transformProblematicTags(readme);
   renderMathViaKatex(readme);
+  cleanTagsFromKatexElements(readme);
   revertNonProblematicTags(readme);
 }
 


### PR DESCRIPTION
Fixes #5 