### PR TITLE
fix: delay initial call to render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,5 +30,9 @@ chrome.runtime.onMessage.addListener((request) => {
 });
 
 // on initial page load
-console.log("initial page load detected");
-renderMath();
+// calls renderMath in the next event loop after document is ready
+// this prevents rendering before the markdown is properly initialised
+setTimeout(() => {
+  console.log("initial page load detected");
+  renderMath();
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],
-      "run_at": "document_start",
+      "run_at": "document_end",
       "js": ["index.js"],
       "css": ["assets/katex.css"]
     }


### PR DESCRIPTION
- Ensure that math is rendered only after the README is properly initialised and loaded
- Prevents occasional corruption of the README on first load