### PR TITLE
Route change should not detect when hash is not changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,13 @@ const readmeObserver = new MutationObserver((mutations) => {
 });
 readmeObserver.observe(document.body, { childList: true, subtree: true });
 
+let currentHash = location.hash;
+
 // on spa-like route changes
 chrome.runtime.onMessage.addListener((request) => {
-  if (request.type === Messages.ROUTE_CHANGED) {
+  if (request.type === Messages.ROUTE_CHANGED && currentHash !== location.hash) {
     console.log("route change detected");
+    currentHash = location.hash;
     renderMath();
   }
 });


### PR DESCRIPTION
Fix https://github.com/AaronCQL/katex-github-chrome-extension/issues/22

At least this fixes the current problem. 
However, please let me know if you know any better or proper way to fix it.